### PR TITLE
issue #2, sanitize irregular keywords when reading .lein-env

### DIFF
--- a/environ.core/src/environ/core.clj
+++ b/environ.core/src/environ/core.clj
@@ -8,6 +8,11 @@
       (str/replace "." "-")
       (keyword)))
 
+(defn- sanitize [k]
+  (let [s (keywordize (name k))]
+    (if-not (= k s) (println "Warning: environ key " k " was has been corrected to " s))
+    s))
+
 (defn- read-system-env []
   (->> (System/getenv)
        (map (fn [[k v]] [(keywordize k) v]))
@@ -21,7 +26,8 @@
 (defn- read-env-file []
   (let [env-file (io/file ".lein-env")]
     (if (.exists env-file)
-      (read-string (slurp env-file)))))
+      (into {} (for [[k v] (read-string (slurp env-file))]
+                 [(sanitize k) v])))))
 
 (def ^{:doc "A map of environment variables."}
   env

--- a/environ.core/test/environ/test/core.clj
+++ b/environ.core/test/environ/test/core.clj
@@ -12,4 +12,8 @@
   (testing "env file"
     (spit ".lein-env" (prn-str {:foo "bar"}))
     (use 'environ.core :reload)
-    (is (= (:foo env) "bar"))))
+    (is (= (:foo env) "bar")))
+  (testing "env file with irregular keys"
+    (spit ".lein-env" (prn-str {:foo.bar "baz"}))
+    (use 'environ.core :reload)
+    (is (= (:foo-bar env) "baz"))))


### PR DESCRIPTION
I've tried to do the most useful thing here, correct the keys but also make sure there's a warning when your keys look incorrect.

Treat this as a straw-man, some other behaviour might be better but it feels like this would work for me.
