### PR TITLE
Add env? to check for the existence of a value

### DIFF
--- a/environ/src/environ/core.clj
+++ b/environ/src/environ/core.clj
@@ -35,3 +35,6 @@
    (read-env-file)
    (read-system-props)
    (read-system-env)))
+
+(defn env? [k]
+  (not (str/blank? (env k))))

--- a/environ/test/environ/test/core.clj
+++ b/environ/test/environ/test/core.clj
@@ -17,3 +17,11 @@
     (spit ".lein-env" (prn-str {:foo.bar "baz"}))
     (use 'environ.core :reload)
     (is (= (:foo-bar env) "baz"))))
+
+(deftest test-env?
+  (testing "does exist"
+    (spit ".lein-env" (prn-str {:foo "bar"}))
+    (use 'environ.core :reload)
+    (is (= (env? :foo) true)))
+  (testing "does not exist"
+    (is (= (env? :qux) false))))


### PR DESCRIPTION
I often find myself adding this utility function to projects that use environ:

```clj
(defn env? [k]
  (not (str/blank? (env key))))
```

`(if (env? :key) ...)` is preferable to `(if (env :key) ...)` because it allows config to be _removed_ by system properties (`-Dkey=""`) or environment variables (`KEY=''`) not just added.

Would you be interested in adding this function to the core? If not, feel free to close this as I understand if you prefer to keep this outside the library.