### PR TITLE
Fix order in jvm options in `java -jar` sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ the "-" character has been replaced with "_".
 You can also use Java system properties:
 
 ```
-java -jar app-standalone.jar -Daws.access.key=XX -Daws.secret.key=YY
+java -Daws.access.key=XX -Daws.secret.key=YY -jar app-standalone.jar
 ```
 
 Note in this case that the "-" character has been replace with ".",


### PR DESCRIPTION
Hello,

I just fixed the order in the sample [as suggested](https://github.com/weavejester/environ/issues/12).

Just out of curiosity, is there a reason not to factorize the [common behavior between the private functions `read-system-env` and `read-system-props`](https://github.com/weavejester/environ/blob/master/environ/src/environ/core.clj#L18-L24)?

Cheers,
