### PR TITLE
Adds environ.core/refresh! to allow changes in .lein-env during REPL use

### DIFF
--- a/environ/src/environ/core.clj
+++ b/environ/src/environ/core.clj
@@ -29,9 +29,17 @@
       (into {} (for [[k v] (read-string (slurp env-file))]
                  [(sanitize k) v])))))
 
-(defonce ^{:doc "A map of environment variables."}
-  env
+(defn- make-env
+  []
   (merge
    (read-env-file)
    (read-system-env)
    (read-system-props)))
+
+(def ^{:doc "A map of environment variables."} env)
+
+(defn refresh!
+  []
+  (alter-var-root #'env (constantly (make-env))))
+
+(refresh!)

--- a/environ/test/environ/test/core.clj
+++ b/environ/test/environ/test/core.clj
@@ -2,15 +2,6 @@
   (:use clojure.test)
   (:require [environ.core :as e]))
 
-(defn refresh-ns []
-  (ns-unalias *ns* 'e)
-  (remove-ns 'environ.core)
-  (dosync (alter @#'clojure.core/*loaded-libs* disj 'environ.core))
-  (require '[environ.core :as e]))
-
-(defn refresh-env []
-  (eval `(do (refresh-ns) e/env)))
-
 (deftest test-env
   (testing "env variables"
     (is (= (:user e/env) (System/getenv "USER")))
@@ -20,9 +11,9 @@
     (is (= (:user-country e/env) (System/getProperty "user.country"))))
   (testing "env file"
     (spit ".lein-env" (prn-str {:foo "bar"}))
-    (let [env (refresh-env)]
+    (let [env (e/refresh!)]
       (is (= (:foo env) "bar"))))
   (testing "env file with irregular keys"
     (spit ".lein-env" (prn-str {:foo.bar "baz"}))
-    (let [env (refresh-env)]
+    (let [env (e/refresh!)]
       (is (= (:foo-bar env) "baz")))))


### PR DESCRIPTION
I have a rather large .lein-env, and make changes to it often enough that I wish I could do it without restarting my REPL/app. I know I could use the approach of unloading `environ.core`, but this seems like it would be generally useful.
