### PR TITLE
Expose a function to read environment.

### DIFF
--- a/environ/src/environ/core.clj
+++ b/environ/src/environ/core.clj
@@ -29,9 +29,12 @@
       (into {} (for [[k v] (read-string (slurp env-file))]
                  [(sanitize k) v])))))
 
-(defonce ^{:doc "A map of environment variables."}
-  env
+(defn read-env []
   (merge
    (read-env-file)
    (read-system-env)
    (read-system-props)))
+
+(defonce ^{:doc "A map of environment variables."}
+  env
+  (read-env))


### PR DESCRIPTION
When using something like [component](https://github.com/stuartsierra/component), it can be nice to have control over when I read the environment, especially in development. Adding a function exposing this functionality seemed innocuous - what do you think?
