### PR TITLE
Improved Exception messages when the .leinenv file has an invalid format

### DIFF
--- a/environ/src/environ/core.clj
+++ b/environ/src/environ/core.clj
@@ -34,50 +34,8 @@
             (throw (java.lang.RuntimeException. "input is not a Clojure map"))))
           (catch java.lang.RuntimeException e
             (throw (java.lang.IllegalArgumentException. (clojure.core/str "Invalid format for .lein-env : " (.getMessage e)))))
-        ;(finally {})
         ))))
 
-(defn- read-env-file-orig []
-  (let [env-file (io/file ".lein-env")]
-    (if (.exists env-file)
-      (into {} (for [[k v] (read-string (slurp env-file))]
-                 [(sanitize k) v])))))
-
-(comment
-(defn fnx
-  [f envinp]
-  (try
-    (do
-  (spit ".lein-env" envinp)
-    (f))
-    (finally (io/delete-file ".lein-env")))
-  )
-  (fnx read-env-file {:foo "bar"})
-  (fnx read-env-file-orig {:foo "bar"})
-
-  (fnx read-env-file " ")
-  (fnx read-env-file-orig " ")
-  (fnx read-env-file "abc ")
-  (fnx read-env-file-orig "abc ")
-  (fnx read-env-file "")
-  (fnx read-env-file-orig "")
-
-(defn read-f
-  [inp]
-(try
-  (let [inpstr (read-string (slurp inp))]
-    (instance? clojure.lang.PersistentArrayMap inpstr)  )
-  ;(for [[k v] (read-string (slurp "/home/kiran/.lein-env-test"))]
-  ;                 [(sanitize k) v])
-  (catch java.lang.RuntimeException e
-    ;(str "got error " (.getMessage e)))
-    (str "got error " ))
-  (finally {})))
-
-(read-f "/home/kiran/.lein-env-test")
-(read-f "/home/kiran/.lein-env-empty")
-(read-env-file)
-  )
 (defonce ^{:doc "A map of environment variables."}
   env
   (merge

--- a/environ/src/environ/core.clj
+++ b/environ/src/environ/core.clj
@@ -26,9 +26,58 @@
 (defn- read-env-file []
   (let [env-file (io/file ".lein-env")]
     (if (.exists env-file)
+      (try
+        (let [inpstr (read-string (slurp env-file))]
+          (if (instance? clojure.lang.PersistentArrayMap inpstr)
+            (into {} (for [[k v] inpstr]
+                   [(sanitize k) v]))
+            (throw (java.lang.RuntimeException. "input is not a Clojure map"))))
+          (catch java.lang.RuntimeException e
+            (throw (java.lang.IllegalArgumentException. (clojure.core/str "Invalid format for .lein-env : " (.getMessage e)))))
+        ;(finally {})
+        ))))
+
+(defn- read-env-file-orig []
+  (let [env-file (io/file ".lein-env")]
+    (if (.exists env-file)
       (into {} (for [[k v] (read-string (slurp env-file))]
                  [(sanitize k) v])))))
 
+(comment
+(defn fnx
+  [f envinp]
+  (try
+    (do
+  (spit ".lein-env" envinp)
+    (f))
+    (finally (io/delete-file ".lein-env")))
+  )
+  (fnx read-env-file {:foo "bar"})
+  (fnx read-env-file-orig {:foo "bar"})
+
+  (fnx read-env-file " ")
+  (fnx read-env-file-orig " ")
+  (fnx read-env-file "abc ")
+  (fnx read-env-file-orig "abc ")
+  (fnx read-env-file "")
+  (fnx read-env-file-orig "")
+
+(defn read-f
+  [inp]
+(try
+  (let [inpstr (read-string (slurp inp))]
+    (instance? clojure.lang.PersistentArrayMap inpstr)  )
+  ;(for [[k v] (read-string (slurp "/home/kiran/.lein-env-test"))]
+  ;                 [(sanitize k) v])
+  (catch java.lang.RuntimeException e
+    ;(str "got error " (.getMessage e)))
+    (str "got error " ))
+  (finally {})))
+
+(read-f "/home/kiran/.lein-env-test")
+(read-f "/home/kiran/.lein-env-empty")
+(read-env-file)
+  )
 (defonce ^{:doc "A map of environment variables."}
   env
   (merge

--- a/environ/test/environ/core_test.clj
+++ b/environ/test/environ/core_test.clj
@@ -1,5 +1,6 @@
 (ns environ.core-test
   (:require [clojure.test :refer :all]
+            [clojure.java.io :as io]
             [environ.core :as e]))
 
 (defn refresh-ns []
@@ -22,7 +23,18 @@
     (spit ".lein-env" (prn-str {:foo "bar"}))
     (let [env (refresh-env)]
       (is (= (:foo env) "bar"))))
+  (testing "env file that's not a Clojure map"
+    (spit ".lein-env" "abc")
+    (is (thrown-with-msg? java.lang.IllegalArgumentException
+                 #"Invalid format for .lein-env : input is not a Clojure map"
+                 (refresh-env))))
+  (testing "env file that's empty "
+    (spit ".lein-env" " ")
+    (is (thrown-with-msg? java.lang.IllegalArgumentException
+                 #"Invalid format for .lein-env : EOF while reading"
+                 (refresh-env))))
   (testing "env file with irregular keys"
     (spit ".lein-env" (prn-str {:foo.bar "baz"}))
     (let [env (refresh-env)]
       (is (= (:foo-bar env) "baz")))))
+(run-tests)

--- a/environ/test/environ/core_test.clj
+++ b/environ/test/environ/core_test.clj
@@ -37,4 +37,3 @@
     (spit ".lein-env" (prn-str {:foo.bar "baz"}))
     (let [env (refresh-env)]
       (is (= (:foo-bar env) "baz")))))
-(run-tests)


### PR DESCRIPTION
If the .lein-env file has format errors (for e.g. empty file, properties not specified as a Clojure map),
attempting to retrieve properties results in exceptions that are do not point to the root cause. 

**Example**:
Let say we have a namespace called example.namespace. If an empty .lein-env file is present in the project root directory, evaluating example.namespace gives an exception thus:
"Failed trying to require example.namespace with: java.lang.Exception: namespace 'environ.core' not found"

I've changed the *environ.core/read-env-file* method to throw an IllegalArgumentException handling 2 errors:

* java.lang.IllegalArgumentException: Invalid format for .lein-env : EOF while reading, _when the .lein-env file is empty_ 
*  java.lang.IllegalArgumentException: Invalid format for .lein-env : input is not a Clojure map, _when the .lein-env file doesn't contain a Clojure map._
              

        
