### PR TITLE
Environment nested associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ environment variables, like so:
 DATABASE_URL=jdbc:postgres://localhost/prod java -jar standalone.jar
 ```
 
-Or use Java system properties:
+Or you can also use Java system properties:
 
 ```bash
 java -Ddatabase.url=jdbc:postgres://localhost/prod -jar standalone.jar
@@ -81,6 +81,34 @@ characters "_" and "." with "-". The environment variable
 `DATABASE_URL` and the system property `database.url` are therefore
 both converted to the same keyword `:database-url`.
 
+## Nested Associations
+
+Leiningen profiles support arbitrarily nested associations. For instance, we might decide to store our database connection information in pieces instead of in fully assembled URLs.
+
+```clojure
+:dev {:env {:database
+  {:db "development" user: "dev"}}}
+:test {:env {:database
+  {:db "test" user: "tst"}}}
+```
+
+Applications can easily access these nested structures:
+
+```clojure
+(get-in env [:database :user])
+;; or
+(-> env :database :user)
+```
+
+If you need to set a nested association via an environment variable use two consecutive underscores for each nesting level:
+
+```bash
+DATABASE__DB=development
+DATABASE__USER=dev
+java -jar standalone.jar
+```
+
+There is no support for setting nested associations from Java system properties. You might like to contribute that feature!
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ environment variables, like so:
 DATABASE_URL=jdbc:postgres://localhost/prod java -jar standalone.jar
 ```
 
-Or you can also use Java system properties:
+Or use Java system properties:
 
 ```bash
 java -Ddatabase.url=jdbc:postgres://localhost/prod -jar standalone.jar

--- a/environ/src/environ/core.clj
+++ b/environ/src/environ/core.clj
@@ -8,15 +8,16 @@
       (str/replace "." "-")
       (keyword)))
 
+(defn- pathize [s]
+  (map keywordize (str/split s #"__")))
+
 (defn- sanitize [k]
   (let [s (keywordize (name k))]
     (if-not (= k s) (println "Warning: environ key " k " has been corrected to " s))
     s))
 
 (defn- read-system-env []
-  (->> (System/getenv)
-       (map (fn [[k v]] [(keywordize k) v]))
-       (into {})))
+  (reduce (fn [m [k v]] (assoc-in m (pathize k) v)) {} (System/getenv)))
 
 (defn- read-system-props []
   (->> (System/getProperties)

--- a/environ/test/environ/core_test.clj
+++ b/environ/test/environ/core_test.clj
@@ -13,8 +13,12 @@
 
 (deftest test-env
   (testing "env variables"
+    ;; These three tests don't really test much unless you set the respective environment variables
+    ;; you've got to do that by hand in your shell since Java doesn't have a System fn for that
     (is (= (:user e/env) (System/getenv "USER")))
-    (is (= (:java-arch e/env) (System/getenv "JAVA_ARCH"))))
+    (is (= (:java-arch e/env) (System/getenv "JAVA_ARCH")))
+    (is (= (get-in e/env [:fake-database :db]) (System/getenv "FAKE_DATABASE__DB"))
+        "should support nested association"))
   (testing "system properties"
     (is (= (:user-name e/env) (System/getProperty "user.name")))
     (is (= (:user-country e/env) (System/getProperty "user.country"))))
@@ -25,4 +29,8 @@
   (testing "env file with irregular keys"
     (spit ".lein-env" (prn-str {:foo.bar "baz"}))
     (let [env (refresh-env)]
-      (is (= (:foo-bar env) "baz")))))
+      (is (= (:foo-bar env) "baz"))))
+  (testing "env file with nested association"
+    (spit ".lein-env" (prn-str {:foo {:bar "baz"}}))
+    (let [env (refresh-env)]
+      (is (= (get-in env [:foo :bar]) "baz")))))


### PR DESCRIPTION
Added support for setting nested associations from environment variables. See [README.md](./README.md) but in short: just use two consecutive underscores in the environment variable name to denote nesting so `export DATABASE__PORT=1234` translates to `:database {:port 1234}`.

Updated [README.md](./README.md) and added a couple tests. The pre-existing tests required manual setting of environment variables. I followed suit with my new environment variable test rather than trying to figure out a way to actually set an environment variable from Clojure. Cursory Google scan indicated it's hard.

Added a nested association for profiles too. It worked without code modifications of course, but it's nice to have it in there for symmetry.

I didn't get into adding support for setting nested associations via Java properties. Left as an exercise for the next contributor.