### PR TITLE
Added support for multiple outputs of the .lein-env file

### DIFF
--- a/lein-environ/src/lein_environ/plugin.clj
+++ b/lein-environ/src/lein_environ/plugin.clj
@@ -3,11 +3,12 @@
   (:require [clojure.java.io :as io]
             leiningen.core.main))
 
-(defn env-file [project]
-  (io/file (:root project) ".lein-env"))
+(defn env-file [path]
+  (io/file path ".lein-env"))
 
 (defn- write-env-to-file [func task-name project args]
-  (spit (env-file project) (prn-str (:env project {})))
+    (doseq [path (clojure.set/union #{(:root project)} (:also-write-to (:lein-environ project) []))]
+      (spit (env-file path) (prn-str (:env project {}))))
   (func task-name project args))
 
 (defn hooks []


### PR DESCRIPTION
For times such as deploying an application to a web server such as Tomcat, it would be useful to be able to place the .lein-env file in additional places such as /resources.

This pull request adds that functionality by looking in project.clj for a :lein-environ map containing the key :also-write-to, whose value is a vector of additional paths relative to project root (e.g., :lein-environ {:also-write-to ["resources"]})