### PR TITLE
Use edn/read-string to read .lein-env

### DIFF
--- a/environ/src/environ/core.clj
+++ b/environ/src/environ/core.clj
@@ -1,5 +1,6 @@
 (ns environ.core
-  (:require [clojure.string :as str]
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
             [clojure.java.io :as io]))
 
 (defn- keywordize [s]
@@ -26,7 +27,7 @@
 (defn- read-env-file []
   (let [env-file (io/file ".lein-env")]
     (if (.exists env-file)
-      (into {} (for [[k v] (read-string (slurp env-file))]
+      (into {} (for [[k v] (edn/read-string (slurp env-file))]
                  [(sanitize k) v])))))
 
 (defonce ^{:doc "A map of environment variables."}

--- a/environ/test/environ/core_test.clj
+++ b/environ/test/environ/core_test.clj
@@ -28,4 +28,7 @@
   (testing "env file with irregular keys"
     (spit ".lein-env" (prn-str {:foo.bar "baz"}))
     (let [env (refresh-env)]
-      (is (= (:foo-bar env) "baz")))))
+      (is (= (:foo-bar env) "baz"))))
+  (testing "env file with irregular keys"
+    (spit ".lein-env" "{:foo #=(str \"bar\" \"baz\")}")
+    (is (thrown? RuntimeException (refresh-env)))))


### PR DESCRIPTION
Under extremely limited circumstances, arbitrary code could be executed by an attacker who had access to the CWD of the java process that used `environ` to access the environment variables.

_*It's important to note that the attacker had to have access to the CWD in order to accomplish the attack*_ so if your system is compromised in this way you have much bigger fish to fry.

This change uses edn's reader to restrict the reading of the file's content to data structures only rather than arbitrary code.

# Functional Testing

- [x] Make a `checkouts` of this in a project and verify that it still behaves the same.