### PR TITLE
Cast non-string values to strings

### DIFF
--- a/environ/src/environ/core.clj
+++ b/environ/src/environ/core.clj
@@ -9,10 +9,16 @@
       (str/replace "." "-")
       (keyword)))
 
-(defn- sanitize [k]
+(defn- sanitize-key [k]
   (let [s (keywordize (name k))]
     (if-not (= k s) (println "Warning: environ key " k " has been corrected to " s))
     s))
+
+(defn- sanitize-val [v]
+  (if (string? v)
+    v
+    (do (println "Warning: environ value" (pr-str v) "has been cast to string")
+        (str v))))
 
 (defn- read-system-env []
   (->> (System/getenv)
@@ -28,7 +34,7 @@
   (let [env-file (io/file ".lein-env")]
     (if (.exists env-file)
       (into {} (for [[k v] (edn/read-string (slurp env-file))]
-                 [(sanitize k) v])))))
+                 [(sanitize-key k) (sanitize-val v)])))))
 
 (defonce ^{:doc "A map of environment variables."}
   env

--- a/environ/test/environ/core_test.clj
+++ b/environ/test/environ/core_test.clj
@@ -31,4 +31,9 @@
       (is (= (:foo-bar env) "baz"))))
   (testing "env file with irregular keys"
     (spit ".lein-env" "{:foo #=(str \"bar\" \"baz\")}")
-    (is (thrown? RuntimeException (refresh-env)))))
+    (is (thrown? RuntimeException (refresh-env))))
+  (testing "env file with non-string values"
+    (spit ".lein-env" (prn-str {:foo 1 :bar :baz}))
+    (let [env (refresh-env)]
+      (is (= (:foo env) "1"))
+      (is (= (:bar env) ":baz")))))


### PR DESCRIPTION
If there is number value in .lein-env file, print warning and cast it to string.

Addressed #36