### PR TITLE
add handling of .boot-env to facilitate testing with boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ $ boot environ -e database-url=jdbc:postgres://localhost/dev repl
 
 The latter form can be included in custom pipelines and `task-options!'.
 
+The task also creates or updates a `.boot-env` file in the fileset.
+This is useful for tasks that create their own pods like 
+[boot-test](https://github.com/adzerk-oss/boot-test), which won't
+see changes in the environ vars.
+
 When you deploy to a production environment, you can make use of
 environment variables, like so:
 

--- a/boot-environ/src/environ/boot.clj
+++ b/boot-environ/src/environ/boot.clj
@@ -1,10 +1,32 @@
 (ns environ.boot
   {:boot/export-tasks true}
   (:require [boot.core :as core]
-            [environ.core :as environ]))
+            [environ.core :as environ]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]))
 
-(core/deftask environ [e env FOO=BAR {kw str} "The environment map"]
-  (fn [next-task]
-    (fn [fileset]
-      (with-redefs [environ/env (merge environ/env env)]
-        (next-task fileset)))))
+(def ^:const env-file ".boot-env")
+
+(defn- read-boot-env [fileset]
+  (if-let [t (core/tmp-get fileset env-file)]
+    (-> t core/tmp-file slurp edn/read-string)
+    {}))
+
+(defn- write-boot-env [env tmp]
+  (spit (io/file tmp env-file) (prn-str env)))
+
+(defn- update-boot-env
+  [fileset tmp-dir env]
+  (doto fileset
+    (-> (read-boot-env) (merge env) (write-boot-env tmp-dir))
+    (-> (core/add-source tmp-dir) (core/commit!))))
+
+(core/deftask environ
+  "Adds key-value pairs to the environment picked up by environ."
+  [e env       FOO=BAR {kw str} "The environment map"]
+  (let [tmp (core/tmp-dir!)]
+    (fn environ-middleware [next-task]
+      (fn environ-handler [fileset]
+        (core/empty-dir! tmp)
+        (with-redefs [environ/env (merge environ/env env)]
+          (next-task (update-boot-env fileset tmp env)))))))

--- a/environ/src/environ/core.clj
+++ b/environ/src/environ/core.clj
@@ -24,8 +24,8 @@
        (map (fn [[k v]] [(keywordize k) v]))
        (into {})))
 
-(defn- read-env-file []
-  (let [env-file (io/file ".lein-env")]
+(defn- read-env-file [f]
+  (if-let [env-file (io/file f)]
     (if (.exists env-file)
       (into {} (for [[k v] (edn/read-string (slurp env-file))]
                  [(sanitize k) v])))))
@@ -33,6 +33,7 @@
 (defonce ^{:doc "A map of environment variables."}
   env
   (merge
-   (read-env-file)
+   (read-env-file ".lein-env")
+   (read-env-file (io/resource ".boot-env"))
    (read-system-env)
    (read-system-props)))


### PR DESCRIPTION
This PR changes the behavior of environ to check for a `.boot-env` file on the classpath.  If it exists, then the key-value pairs within the file are added to the environment.  This addresses issue #46.