### PR TITLE
Set *print-xxx* to false when writing env-file

### DIFF
--- a/boot-environ/src/environ/boot.clj
+++ b/boot-environ/src/environ/boot.clj
@@ -7,13 +7,20 @@
 
 (def ^:const env-file ".boot-env")
 
+(defn- as-edn [& args]
+  (binding [*print-dup*    false
+            *print-meta*   false
+            *print-length* false
+            *print-level*  false]
+    (apply prn-str args)))
+
 (defn- read-boot-env [fileset]
   (if-let [t (core/tmp-get fileset env-file)]
     (-> t core/tmp-file slurp edn/read-string)
     {}))
 
 (defn- write-boot-env [env tmp]
-  (spit (io/file tmp env-file) (prn-str env)))
+  (spit (io/file tmp env-file) (as-edn env)))
 
 (defn- update-boot-env
   [fileset tmp-dir env]

--- a/lein-environ/src/lein_environ/plugin.clj
+++ b/lein-environ/src/lein_environ/plugin.clj
@@ -3,11 +3,18 @@
   (:require [clojure.java.io :as io]
             leiningen.core.main))
 
+(defn- as-edn [& args]
+  (binding [*print-dup*    false
+            *print-meta*   false
+            *print-length* false
+            *print-level*  false]
+    (apply prn-str args)))
+
 (defn env-file [project]
   (io/file (:root project) ".lein-env"))
 
 (defn- write-env-to-file [func task-name project args]
-  (spit (env-file project) (prn-str (:env project {})))
+  (spit (env-file project) (as-edn (:env project {})))
   (func task-name project args))
 
 (defn hooks []


### PR DESCRIPTION
In the Leiningen and Boot plugins, several dynamic variables altering `prn-str` and friends may be turned on when the hook/task is called, and cause their output to not be EDN-compliant. As a result, the environ file could potentially not contain EDN data.

This happens in technomancy/leiningen#2096, and although that particular issue will be fixed upstream, I am guessing this could cause trouble from time to time (perhaps this is a bigger concern in Boot?).

I am not sure whether this warrants a fix here or where the hook/task may be called, but I made a pull request either way. The patch ensures the dynamic variables are set to false when the environ file is written.