### PR TITLE
Ensure updated fileset is returned

### DIFF
--- a/boot-environ/src/environ/boot.clj
+++ b/boot-environ/src/environ/boot.clj
@@ -24,9 +24,9 @@
 
 (defn- update-boot-env
   [fileset tmp-dir env]
-  (doto fileset
-    (-> (read-boot-env) (merge env) (write-boot-env tmp-dir))
-    (-> (core/add-source tmp-dir) (core/commit!))))
+  (do
+    (-> fileset (read-boot-env) (merge env) (write-boot-env tmp-dir))
+    (-> fileset (core/add-source tmp-dir) (core/commit!))))
 
 (core/deftask environ
   "Adds key-value pairs to the environment picked up by environ."


### PR DESCRIPTION
In local testing this change appears to fix the problem we've been having getting environ variables to load into our boot-test task. 

This should close #56.