### PR TITLE
`override!` function for modifying the environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ characters "_" and "." with "-". The environment variable
 `DATABASE_URL` and the system property `database.url` are therefore
 both converted to the same keyword `:database-url`.
 
+The `override!` function modifies the environment. It is not
+recommended in production, but can be convenient when testing code in
+the REPL during development:
+
+```clojure
+(require '[environ.core :as environ :refer [env]])
+
+(environ/override! :database-url "jdbc:postgres://localhost/dev")
+```
+
 
 ## License
 

--- a/environ/src/environ/core.clj
+++ b/environ/src/environ/core.clj
@@ -43,3 +43,10 @@
    (read-env-file (io/resource ".boot-env"))
    (read-system-env)
    (read-system-props)))
+
+(defn override!
+  "Modify the environment. Intended to be used only from the REPL during
+  developement."
+  [k v]
+  (let [k (sanitize-key k)]
+    (def env (assoc env k (sanitize-val k v)))))


### PR DESCRIPTION
I was trying to avoid having to do something like this, as I think environ's approach of never modifying the environment is a good design. But having to restart the JVM to make an environment change during development was too much of an inconvenience: it made it too tempting to make a quick change to my code instead, and hack in a literal value in place of the `(:env …)` form. Today, I accidentally committed a change like that, and it made it to production.

So I hope you will accept this PR, which provides a less dangerous mechanism. I have tried to make it abundantly clear that it's only for use in the REPL during development, and not for production use.