### PR TITLE
Replace :project namespaced keywords with value from project.clj

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ The first two sources are set by the lein-environ and boot-environ
 plugins respectively, and should not be edited manually.
 
 The `.lein-env` file is populated with the content of the `:env` key
-in the Leiningen project map.
+in the Leiningen project map. Keywords with a `project` namespace are
+looked up in the project map. For example:
+
+```clojure
+{:env {:app-version :project/version}}
+```
+
+This looks up the `:version` key in the Leiningen project map. You can view
+the full project map by using [lein-pprint](https://github.com/technomancy/leiningen/tree/master/lein-pprint).
 
 The `.boot-env` file is populated by the `environ.boot/environ` Boot
 task.
@@ -96,7 +104,7 @@ $ boot environ -e database-url=jdbc:postgres://localhost/dev repl
 The latter form can be included in custom pipelines and `task-options!'.
 
 The task also creates or updates a `.boot-env` file in the fileset.
-This is useful for tasks that create their own pods like 
+This is useful for tasks that create their own pods like
 [boot-test](https://github.com/adzerk-oss/boot-test), which won't
 see changes in the environ vars.
 

--- a/lein-environ/src/lein_environ/plugin.clj
+++ b/lein-environ/src/lein_environ/plugin.clj
@@ -10,11 +10,22 @@
             *print-level*  false]
     (apply prn-str args)))
 
+(defn- map-vals [f m]
+  (reduce-kv #(assoc %1 %2 (f %3)) {} m))
+
+(defn- replace-project-keyword [value project]
+  (if (and (keyword? value) (= (namespace value) "project"))
+    (project (keyword (name value)))
+    value))
+
+(defn read-env [project]
+  (map-vals #(replace-project-keyword % project) (:env project {})))
+
 (defn env-file [project]
   (io/file (:root project) ".lein-env"))
 
 (defn- write-env-to-file [func task-name project args]
-  (spit (env-file project) (as-edn (:env project {})))
+  (spit (env-file project) (as-edn (read-env project)))
   (func task-name project args))
 
 (defn hooks []

--- a/lein-environ/test/lein_environ/plugin_test.clj
+++ b/lein-environ/test/lein_environ/plugin_test.clj
@@ -1,0 +1,11 @@
+(ns lein-environ.plugin-test
+  (:require [clojure.test :refer :all]
+            [lein-environ.plugin :as l]))
+
+(deftest replace-project-keyword-test
+  (are [expected project] (= expected (l/read-env project))
+    {:app-version "1.0.0", :test-version :version}
+    {:version "1.0.0", :env {:app-version :project/version :test-version :version}}
+
+    {:foo "bar"}
+    {:env {:foo "bar"}}))


### PR DESCRIPTION
Leiningen has a [feature][1] where keywords like :project/version in aliases are replaced with the value of the key :version from the project map. This commit adds the same behaviour to values in the :env map.

There's quite a few ways to write this, let me know if you want me to change it. If you're happy with the intent of the PR, I can write docs for it too.

[1]: https://github.com/technomancy/leiningen/blob/2.6.1/leiningen-core/src/leiningen/core/main.clj#L260-L267