### PR TITLE
read .lein-docker-env file if present

### DIFF
--- a/environ/src/environ/core.clj
+++ b/environ/src/environ/core.clj
@@ -40,6 +40,7 @@
   env
   (merge
    (read-env-file ".lein-env")
+   (read-env-file ".lein-docker-env")
    (read-env-file (io/resource ".boot-env"))
    (read-system-env)
    (read-system-props)))


### PR DESCRIPTION
Hi - I don't really expect you to merge this PR as is, it's more intended as a way to ask what the best way to approach getting something like this into environ would be.

I'm putting together a small leiningen plugin, [lein-docker-compose](https://github.com/rsslldnphy/lein-docker-compose) that reads a project's `docker-compose.yml`, discovers what ports the services in them have been mapped to, and adds these port mappings to a `.lein-docker-env` file in the same format as `.lein-env`, with the intention of having environ pick them up and add them to `env`.

I'm guessing you probably don't want to litter environ with random `.lein-*-env` files to support different projects. But if there was a neat way to allow arbitrary user-defined extra `-env` files, would that be something you'd be interested in supporting? Not sure exactly where you'd set up that user-defined setting though... Or is there an easier/better way to achieve what I'm after?

Thanks,

Russell