### PR TITLE
update README with clearer instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Include the following dependency in your `project.clj` file:
 ```
 
 If you want to be able to draw settings from the Leiningen project
-map, you'll also need the following plugin:
+map `project.clj` or `profiles.clj`, you'll also need the following plugin:
 
 ```clojure
 :plugins [[lein-environ "1.1.0"]]


### PR DESCRIPTION
make it bit more clear that the lein-environ plugin is needed to access profiles.clj