### PR TITLE
Reverse the construction of environ.core/env to resolve variable in the correct order

### DIFF
--- a/environ/src/environ/core.clj
+++ b/environ/src/environ/core.clj
@@ -39,7 +39,7 @@
 (defonce ^{:doc "A map of environment variables."}
   env
   (merge
-   (read-env-file ".lein-env")
-   (read-env-file (io/resource ".boot-env"))
+   (read-system-props)
    (read-system-env)
-   (read-system-props)))
+   (read-env-file (io/resource ".boot-env"))
+   (read-env-file ".lein-env")))


### PR DESCRIPTION
The README suggests that environment variables should be resolved in the following order:
- A .lein-env file in the project directory
- A .boot-env file on the classpath
- Environment variables
- Java system properties

However, the current implementation does not reflect the order described (see below):

```
(defonce ^{:doc "A map of environment variables."}
  env
  (merge
   (read-env-file ".lein-env")
   (read-env-file (io/resource ".boot-env"))
   (read-system-env)
   (read-system-props)))
```

clojure.core/merge overrides values from right to left (arg 1 < arg 2 < arg 3 ...):
```
(merge {:a 1 :b 2 :c 3} {:a 9 :b 8 :d 7})
=> {:a 9, :b 8, :c 3, :d 7}
```

My PR rewrites the order as follow to reflect the property of clojure.core/merge

```
(defonce ^{:doc "A map of environment variables."}
  env
  (merge
   (read-system-props)
   (read-system-env)
   (read-env-file (io/resource ".boot-env"))
   (read-env-file ".lein-env")))
```