### PR TITLE
Update README for creating composite profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ on the `environ.core/env` map.
 
 The value of this key can be set in several different ways. The most
 common way during development is to use a local `profiles.clj` file in
-your project directory. This file contained a map that is merged with
-the standard `project.clj` file, but can be kept out of version
-control and reserved for local development options.
+your project directory. This file contains a map with profiles that will
+be merged with the profiles specified in the standard `project.clj`, but
+can be kept out of version control and reserved for local development options.
 
 ```clojure
 {:dev  {:env {:database-url "jdbc:postgresql://localhost/dev"}}
@@ -79,6 +79,24 @@ control and reserved for local development options.
 In this case we add a database URL for the dev and test environments.
 This means that if you run `lein repl`, the dev database will be used,
 and if you run `lein test`, the test database will be used.
+
+So that profiles you define in `profiles.clj` are merged into, rather than
+replacing profiles defined in `project.clj`, a composite profile can be
+created in `project.clj`:
+
+```clojure
+:profiles {:dev [:project/dev :profiles/dev]
+           :test [:project/test :profiles/test]
+           ;; only edit :profiles/* in profiles.clj
+           :profiles/dev  {}
+           :profiles/test {}
+           :project/dev {:source-paths ["src" "tool-src"]
+                         :dependencies [[midje "1.6.3"]]
+                         :plugins [[lein-auto "0.1.3"]]}
+           :project/test {}}
+```
+
+And then use the `:profiles/dev` key in your `profiles.clj`.
 
 Keywords with a `project` namespace are looked up in the project
 map. For example:


### PR DESCRIPTION
I believe this closes #19 and closes #15. 

I ran into this today (dependencies from a profile were mysteriously not loading), thought I'd save others from a disastrous fate by updating the readme to mention this.

I adopted @weavejester's suggestion from #15 with profiles prefixed with `:project`.