### PR TITLE
Fix advanced compilation issue

### DIFF
--- a/environ/src/environ/core.cljc
+++ b/environ/src/environ/core.cljc
@@ -46,8 +46,8 @@
   #?(:clj (when-let [f (io/file f)]
             (when (.exists f)
               (slurp f)))
-     :cljs (when (.existsSync fs f)
-             (str (.readFileSync fs f)))))
+     :cljs (when ^js (.existsSync fs f)
+             (str ^js (.readFileSync fs f)))))
 
 (defn- read-env-file [f]
   (when-let [content (slurp-file f)]


### PR DESCRIPTION
When used in ClojureScript with advanced compilation, this place was throwing an error, due to method names `existsSync` and `readFileSync` are being mangled.
This PR fixes it by wrapping the method names with `goog.object.get`