### PR TITLE
Add runtime-env for graalvm native-image support

### DIFF
--- a/environ/src/environ/core.cljc
+++ b/environ/src/environ/core.cljc
@@ -77,5 +77,8 @@
               (read-system-env))
              {})))
 
-(defonce ^{:doc "A map of environment variables."}
+(defonce ^{:doc "A map of environment variables at compile time."}
   env (read-env))
+
+(def ^{:doc "A ref to a map of environment variables at runtime."}
+  runtime-env (delay (read-env)))


### PR DESCRIPTION
I added `core/runtime-env` to better support graalvm native-image (where `core/env` reflects the compile time environment).

Since it's a delay you just deref it:

```clojure
(require '[environ.core :as environ])
@environ/runtime-env
```

...and it returns the same data structure as `core/env` but reflects the runtime config environment.

It is a delay so that you it loads the config the first time you deref `runtime-env` but then caches it after that (like `env` does for compile time config).